### PR TITLE
Remove error producing parts in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ settings = {"saml":[{
      "dynamicProfile": true // set to true if we want to create a user in Meteor.users dynamically if SAML assertion is valid
      "identifierFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", // Defaults to urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
      "localProfileMatchAttribute": "telephoneNumber" // CAUTION: this will be mapped to profile.<localProfileMatchAttribute> attribute in Mongo if identifierFormat (see above) differs from urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress,
-     "attributesSAML": {[telephoneNumber, sn, givenName, mail]}, // attrs from SAML attr statement, which will be used for local Meteor profile creation. Currently no real attribute mapping. If required use mapping on IdP side.
+     "attributesSAML": [telephoneNumber, sn, givenName, mail], // attrs from SAML attr statement, which will be used for local Meteor profile creation. Currently no real attribute mapping. If required use mapping on IdP side.
 
   }]}
 
@@ -49,13 +49,13 @@ in some template
 in helper function
 
 ```
-'click .saml-login': function(event, template){
+  'click .saml-login' (event) {
     event.preventDefault();
-    var provider = $(event.target).data('provider');
+    var provider = event.target.getAttribute('data-provider');
     Meteor.loginWithSaml({
-	    provider:provider
-	}, function(error, result){
-		//handle errors and result
+      provider
+    }, function(error, result) {
+      //handle errors and result
     });
   }
 ```


### PR DESCRIPTION
Removed surrounding parentheses as they were preventing settings.json file from being properly read. 
```
 "attributesSAML": [telephoneNumber, sn, givenName, mail], 
```
Also, modified the helper function to be a bit more concise and use a bit of ES6 features. 
```
  'click .saml-login' (event) {
    event.preventDefault();
    let provider = event.target.getAttribute('data-provider');
    Meteor.loginWithSaml({
      provider
    }, function(error, result) {
      //handle errors and result
    });
  }
```
