### PR TITLE
Fix nameId attributes in SAML logout request

### DIFF
--- a/saml_server.js
+++ b/saml_server.js
@@ -213,7 +213,9 @@ Accounts.registerLoginHandler(function(loginRequest) {
             provider: Accounts.saml.RelayState,
             idp: loginResult.profile.issuer,
             idpSession: loginResult.profile.sessionIndex,
-            nameID: loginResult.profile.nameID
+            nameID: loginResult.profile.nameID,
+            nameIDFormat: loginResult.profile.nameIDFormat,
+            nameIDNameQualifier: loginResult.profile.nameIDNameQualifier
         };
 
         Meteor.users.update({

--- a/saml_server.js
+++ b/saml_server.js
@@ -42,6 +42,8 @@ Meteor.methods({
             "services.saml": 1
         });
         var nameID = user.services.saml.nameID;
+        var nameIDFormat = user.services.saml.nameIDFormat;
+        var nameIDNameQualifier = user.services.saml.nameIDNameQualifier;
         var sessionIndex = nameID = user.services.saml.idpSession;
         if (Meteor.settings.debug) {
             console.log("NameID for user " + Meteor.userId() + " found: " + JSON.stringify(nameID));
@@ -51,6 +53,8 @@ Meteor.methods({
 
         var request = _saml.generateLogoutRequest({
             nameID: nameID,
+            nameIDFormat: nameIDFormat,
+            nameIDNameQualifier: nameIDNameQualifier,
             sessionIndex: sessionIndex
         });
 

--- a/saml_utils.js
+++ b/saml_utils.js
@@ -417,6 +417,10 @@ SAML.prototype.validateResponse = function(samlResponse, relayState, callback) {
                         if (nameID.hasAttribute('Format')) {
                             profile.nameIDFormat = nameID.getAttribute('Format');
                         }
+
+                        if (nameID.hasAttribute('NameQualifier')) {
+                            profile.nameIDNameQualifier = nameID.getAttribute('NameQualifier');
+                        }
                     }
                 }
 

--- a/saml_utils.js
+++ b/saml_utils.js
@@ -107,7 +107,9 @@ SAML.prototype.generateAuthorizeRequest = function(req) {
 
 SAML.prototype.generateLogoutRequest = function(options) {
     // options should be of the form
-    // nameId: <nameId as submitted during SAML SSO>
+    // nameID: <nameId as submitted during SAML SSO>
+    // nameIDFormat: <nameId Format as submitted during SAML SSO>
+    // nameIDNameQualifier: <nameId NameQualifier as submitted during SAML SSO>
     // sessionIndex: sessionIndex
     // --- NO SAMLsettings: <Meteor.setting.saml  entry for the provider you want to SLO from
 
@@ -128,11 +130,17 @@ SAML.prototype.generateLogoutRequest = function(options) {
         `Destination="${ this.options.idpSLORedirectURL }" ` +
         '>' +
         `<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">${ this.options.issuer }</saml:Issuer>` +
-        '<saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ' +
-        'NameQualifier="http://id.init8.net:8080/openam" ' +
-        `SPNameQualifier="${ this.options.issuer }" ` +
-        `Format="${ this.options.identifierFormat }">${
-		options.nameID }</saml:NameID>` +
+        '<saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ';
+    if (options.nameIDNameQualifier) {
+        request += `NameQualifier="${ options.nameIDNameQualifier }" `;
+    }
+    if (options.nameIDFormat) {
+        request += `Format="${ options.nameIDFormat }" `;
+    }
+    else {
+        request += `Format="${ this.options.identifierFormat }" `;
+    }
+    request += `>${ options.nameID }</saml:NameID>` +
         `<samlp:SessionIndex xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">${ options.sessionIndex }</samlp:SessionIndex>` +
         '</samlp:LogoutRequest>';
     if (Meteor.settings.debug) {


### PR DESCRIPTION
Hello,

The _nameId_ attributes in logout request is currently partially hard-corded when in _SAML_ standard, we have to put same attributes as submitted during _SAML SSO_. This _PR_ fix that by retrieving, storing and reusing this attributes during _SAML SLO_.

**Note :** This fix permit to be compliant with _Lasso_ based _Identity providers_.

Regards, 